### PR TITLE
Add basic simulcast messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Use the command below:
 protoc --doc_out=./doc --doc_opt=markdown,docs.md fishjam/**/*.proto
 ```
 
+## Lint and formatting
+
+The files can be formatted using `buf`. 
+Check out [installation page](https://buf.build/docs/installation/) for `buf`.
+
+```
+buf format -w
+```
+
+and linted
+```
+buf lint
+```
+
 ## Copyright and License
 
 Copyright 2023, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=fishjam-protos)

--- a/fishjam/media_events/peer/peer.proto
+++ b/fishjam/media_events/peer/peer.proto
@@ -43,12 +43,12 @@ message MediaEvent {
   message SdpOffer {
     string sdp_offer = 1;
     map<string, string> track_id_to_metadata_json = 2;
-    map<string, TrackBitrate> track_id_to_bitrates = 3;
+    map<string, TrackBitrates> track_id_to_bitrates = 3;
     map<string, string> mid_to_track_id = 4;
   }
 
   // Sent when Peer wants to update its track's bitrate
-  message TrackBitrate {
+  message TrackBitrates {
     string track_id = 1;
     repeated VariantBitrate variant_bitrates = 2;
   }
@@ -73,7 +73,7 @@ message MediaEvent {
     RenegotiateTracks renegotiate_tracks = 5;
     media_events.Candidate candidate = 6;
     SdpOffer sdp_offer = 7;
-    TrackBitrate track_bitrate = 8;
+    TrackBitrates track_bitrates = 8;
     EnableTrackVariant enable_track_variant = 9;
     DisableTrackVariant disable_track_variant = 10;
   }

--- a/fishjam/media_events/peer/peer.proto
+++ b/fishjam/media_events/peer/peer.proto
@@ -6,6 +6,13 @@ import "fishjam/media_events/shared.proto";
 
 // Defines any type of message sent from Peer to Membrane RTC Engine
 message MediaEvent {
+  // SCHEMAS
+
+  message VariantBitrate {
+    media_events.Variant variant = 1;
+    int32 bitrate = 2;
+  }
+
   // MEDIA EVENTS
 
   // Sent when a peer wants to join WebRTC Endpoint.
@@ -43,7 +50,28 @@ message MediaEvent {
   // Sent when Peer wants to update its track's bitrate
   message TrackBitrate {
     string track_id = 1;
-    int32 bitrate = 2;
+    repeated VariantBitrate variant_bitrates = 2;
+  }
+
+  // Sent when client disables one of the track variants
+  message DisableTrackVariant {
+    string track_id = 1;
+    media_events.Variant variant = 2;
+  }
+
+  // Sent when client enables one of the track variants
+  message EnableTrackVariant {
+    string track_id = 1;
+    media_events.Variant variant = 2;
+  }
+
+  // Informs that a client wants to receive a specific track variant.
+  // The track variant will be sent whenever it is available.
+  // If choosen variant is unavailable, an other variant will be
+  // sent until the choosen variant becomes active again.
+  message SetTargetTrackVariant {
+    string track_id = 1;
+    media_events.Variant variant = 2;
   }
 
   oneof content {
@@ -55,5 +83,8 @@ message MediaEvent {
     media_events.Candidate candidate = 6;
     SdpOffer sdp_offer = 7;
     TrackBitrate track_bitrate = 8;
+    EnableTrackVariant enable_track_variant = 9;
+    DisableTrackVariant disable_track_variant = 10;
+    SetTargetTrackVariant set_target_track_variant = 11;
   }
 }

--- a/fishjam/media_events/peer/peer.proto
+++ b/fishjam/media_events/peer/peer.proto
@@ -65,15 +65,6 @@ message MediaEvent {
     media_events.Variant variant = 2;
   }
 
-  // Informs that a client wants to receive a specific track variant.
-  // The track variant will be sent whenever it is available.
-  // If choosen variant is unavailable, an other variant will be
-  // sent until the choosen variant becomes active again.
-  message SetTargetTrackVariant {
-    string track_id = 1;
-    media_events.Variant variant = 2;
-  }
-
   oneof content {
     Connect connect = 1;
     Disconnect disconnect = 2;
@@ -85,6 +76,5 @@ message MediaEvent {
     TrackBitrate track_bitrate = 8;
     EnableTrackVariant enable_track_variant = 9;
     DisableTrackVariant disable_track_variant = 10;
-    SetTargetTrackVariant set_target_track_variant = 11;
   }
 }

--- a/fishjam/media_events/server/server.proto
+++ b/fishjam/media_events/server/server.proto
@@ -7,6 +7,17 @@ import "fishjam/media_events/shared.proto";
 // Defines any type of message sent from Membrane RTC Engine to Peer
 message MediaEvent {
   // SCHEMAS
+  message Track {
+    message SimulcastConfig {
+      bool enabled = 1;
+      repeated media_events.Variant active_variants = 2;
+      repeated media_events.Variant disabled_variants = 3;
+    }
+
+    string track_id = 1;
+    string metadata_json = 2;
+    SimulcastConfig simulcast_config = 3;
+  }
 
   message Endpoint {
     string endpoint_type = 2;
@@ -100,6 +111,27 @@ message MediaEvent {
     Status status = 2;
   }
 
+  // Informs that track's variant has been changed
+  message TrackVariantSwitched {
+    string endpoint_id = 1;
+    string track_id = 2;
+    media_events.Variant variant = 3;
+  }
+
+  // Sent when track's variant has been disabled
+  message TrackVariantDisabled {
+    string endpoint_id = 1;
+    string track_id = 2;
+    media_events.Variant variant = 3;
+  }
+
+  // Sent when track's variant has been enabled
+  message TrackVariantEnabled {
+    string endpoint_id = 1;
+    string track_id = 2;
+    media_events.Variant variant = 3;
+  }
+
   oneof content {
     EndpointUpdated endpoint_updated = 1;
     TrackUpdated track_updated = 2;
@@ -113,5 +145,8 @@ message MediaEvent {
     media_events.Candidate candidate = 10;
     SdpAnswer sdp_answer = 11;
     VadNotification vad_notification = 12;
+    TrackVariantSwitched track_variant_switched = 13;
+    TrackVariantDisabled track_variant_disabled = 14;
+    TrackVariantEnabled track_variant_enabled = 15;
   }
 }

--- a/fishjam/media_events/server/server.proto
+++ b/fishjam/media_events/server/server.proto
@@ -10,7 +10,7 @@ message MediaEvent {
   message Track {
     message SimulcastConfig {
       bool enabled = 1;
-      repeated media_events.Variant active_variants = 2;
+      repeated media_events.Variant enabled_variants = 2;
       repeated media_events.Variant disabled_variants = 3;
     }
 

--- a/fishjam/media_events/server/server.proto
+++ b/fishjam/media_events/server/server.proto
@@ -14,15 +14,14 @@ message MediaEvent {
       repeated media_events.Variant disabled_variants = 3;
     }
 
-    string track_id = 1;
-    string metadata_json = 2;
-    SimulcastConfig simulcast_config = 3;
+    string metadata_json = 1;
+    SimulcastConfig simulcast_config = 2;
   }
 
   message Endpoint {
     string endpoint_type = 2;
     string metadata_json = 3;
-    map<string, string> track_id_to_metadata_json = 4;
+    map<string, Track> track_id_to_track = 4;
   }
 
   message IceServer {
@@ -49,7 +48,7 @@ message MediaEvent {
   //  Sent to informs that one of the peers has added one or more tracks.
   message TracksAdded {
     string endpoint_id = 1;
-    map<string, string> track_id_to_metadata_json = 2;
+    map<string, Track> track_id_to_track = 2;
   }
 
   //  Sent to informs that one of the peers has removed one or more tracks.
@@ -67,7 +66,7 @@ message MediaEvent {
   // Sent to the peer after connecting to the WebRTC Endpoint.
   message Connected {
     string endpoint_id = 1;
-    map<string, Endpoint> endpoints_id_to_endpoint = 2;
+    map<string, Endpoint> endpoint_id_to_endpoint = 2;
     repeated IceServer ice_servers = 3;
   }
 

--- a/fishjam/media_events/shared.proto
+++ b/fishjam/media_events/shared.proto
@@ -9,3 +9,10 @@ message Candidate {
   string sdp_mid = 3;
   string username_fragment = 4;
 }
+
+enum Variant {
+  VARIANT_UNSPECIFIED = 0;
+  VARIANT_LOW = 1;
+  VARIANT_MEDIUM = 2;
+  VARIANT_HIGH = 3;
+}

--- a/fishjam_protos/lib/fishjam/media_events/peer/peer.pb.ex
+++ b/fishjam_protos/lib/fishjam/media_events/peer/peer.pb.ex
@@ -59,7 +59,7 @@ defmodule Fishjam.MediaEvents.Peer.MediaEvent.SdpOffer.TrackIdToBitratesEntry do
   use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field :key, 1, type: :string
-  field :value, 2, type: Fishjam.MediaEvents.Peer.MediaEvent.TrackBitrate
+  field :value, 2, type: Fishjam.MediaEvents.Peer.MediaEvent.TrackBitrates
 end
 
 defmodule Fishjam.MediaEvents.Peer.MediaEvent.SdpOffer.MidToTrackIdEntry do
@@ -97,7 +97,7 @@ defmodule Fishjam.MediaEvents.Peer.MediaEvent.SdpOffer do
     map: true
 end
 
-defmodule Fishjam.MediaEvents.Peer.MediaEvent.TrackBitrate do
+defmodule Fishjam.MediaEvents.Peer.MediaEvent.TrackBitrates do
   @moduledoc false
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
@@ -120,15 +120,6 @@ defmodule Fishjam.MediaEvents.Peer.MediaEvent.DisableTrackVariant do
 end
 
 defmodule Fishjam.MediaEvents.Peer.MediaEvent.EnableTrackVariant do
-  @moduledoc false
-
-  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
-
-  field :track_id, 1, type: :string, json_name: "trackId"
-  field :variant, 2, type: Fishjam.MediaEvents.Variant, enum: true
-end
-
-defmodule Fishjam.MediaEvents.Peer.MediaEvent.SetTargetTrackVariant do
   @moduledoc false
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
@@ -169,9 +160,9 @@ defmodule Fishjam.MediaEvents.Peer.MediaEvent do
     json_name: "sdpOffer",
     oneof: 0
 
-  field :track_bitrate, 8,
-    type: Fishjam.MediaEvents.Peer.MediaEvent.TrackBitrate,
-    json_name: "trackBitrate",
+  field :track_bitrates, 8,
+    type: Fishjam.MediaEvents.Peer.MediaEvent.TrackBitrates,
+    json_name: "trackBitrates",
     oneof: 0
 
   field :enable_track_variant, 9,
@@ -182,10 +173,5 @@ defmodule Fishjam.MediaEvents.Peer.MediaEvent do
   field :disable_track_variant, 10,
     type: Fishjam.MediaEvents.Peer.MediaEvent.DisableTrackVariant,
     json_name: "disableTrackVariant",
-    oneof: 0
-
-  field :set_target_track_variant, 11,
-    type: Fishjam.MediaEvents.Peer.MediaEvent.SetTargetTrackVariant,
-    json_name: "setTargetTrackVariant",
     oneof: 0
 end

--- a/fishjam_protos/lib/fishjam/media_events/peer/peer.pb.ex
+++ b/fishjam_protos/lib/fishjam/media_events/peer/peer.pb.ex
@@ -1,3 +1,12 @@
+defmodule Fishjam.MediaEvents.Peer.MediaEvent.VariantBitrate do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :variant, 1, type: Fishjam.MediaEvents.Variant, enum: true
+  field :bitrate, 2, type: :int32
+end
+
 defmodule Fishjam.MediaEvents.Peer.MediaEvent.Connect do
   @moduledoc false
 
@@ -94,7 +103,38 @@ defmodule Fishjam.MediaEvents.Peer.MediaEvent.TrackBitrate do
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field :track_id, 1, type: :string, json_name: "trackId"
-  field :bitrate, 2, type: :int32
+
+  field :variant_bitrates, 2,
+    repeated: true,
+    type: Fishjam.MediaEvents.Peer.MediaEvent.VariantBitrate,
+    json_name: "variantBitrates"
+end
+
+defmodule Fishjam.MediaEvents.Peer.MediaEvent.DisableTrackVariant do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :track_id, 1, type: :string, json_name: "trackId"
+  field :variant, 2, type: Fishjam.MediaEvents.Variant, enum: true
+end
+
+defmodule Fishjam.MediaEvents.Peer.MediaEvent.EnableTrackVariant do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :track_id, 1, type: :string, json_name: "trackId"
+  field :variant, 2, type: Fishjam.MediaEvents.Variant, enum: true
+end
+
+defmodule Fishjam.MediaEvents.Peer.MediaEvent.SetTargetTrackVariant do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :track_id, 1, type: :string, json_name: "trackId"
+  field :variant, 2, type: Fishjam.MediaEvents.Variant, enum: true
 end
 
 defmodule Fishjam.MediaEvents.Peer.MediaEvent do
@@ -132,5 +172,20 @@ defmodule Fishjam.MediaEvents.Peer.MediaEvent do
   field :track_bitrate, 8,
     type: Fishjam.MediaEvents.Peer.MediaEvent.TrackBitrate,
     json_name: "trackBitrate",
+    oneof: 0
+
+  field :enable_track_variant, 9,
+    type: Fishjam.MediaEvents.Peer.MediaEvent.EnableTrackVariant,
+    json_name: "enableTrackVariant",
+    oneof: 0
+
+  field :disable_track_variant, 10,
+    type: Fishjam.MediaEvents.Peer.MediaEvent.DisableTrackVariant,
+    json_name: "disableTrackVariant",
+    oneof: 0
+
+  field :set_target_track_variant, 11,
+    type: Fishjam.MediaEvents.Peer.MediaEvent.SetTargetTrackVariant,
+    json_name: "setTargetTrackVariant",
     oneof: 0
 end

--- a/fishjam_protos/lib/fishjam/media_events/server/server.pb.ex
+++ b/fishjam_protos/lib/fishjam/media_events/server/server.pb.ex
@@ -15,10 +15,10 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.Track.SimulcastConfig do
 
   field :enabled, 1, type: :bool
 
-  field :active_variants, 2,
+  field :enabled_variants, 2,
     repeated: true,
     type: Fishjam.MediaEvents.Variant,
-    json_name: "activeVariants",
+    json_name: "enabledVariants",
     enum: true
 
   field :disabled_variants, 3,

--- a/fishjam_protos/lib/fishjam/media_events/server/server.pb.ex
+++ b/fishjam_protos/lib/fishjam/media_events/server/server.pb.ex
@@ -33,21 +33,20 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.Track do
 
   use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
-  field :track_id, 1, type: :string, json_name: "trackId"
-  field :metadata_json, 2, type: :string, json_name: "metadataJson"
+  field :metadata_json, 1, type: :string, json_name: "metadataJson"
 
-  field :simulcast_config, 3,
+  field :simulcast_config, 2,
     type: Fishjam.MediaEvents.Server.MediaEvent.Track.SimulcastConfig,
     json_name: "simulcastConfig"
 end
 
-defmodule Fishjam.MediaEvents.Server.MediaEvent.Endpoint.TrackIdToMetadataJsonEntry do
+defmodule Fishjam.MediaEvents.Server.MediaEvent.Endpoint.TrackIdToTrackEntry do
   @moduledoc false
 
   use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field :key, 1, type: :string
-  field :value, 2, type: :string
+  field :value, 2, type: Fishjam.MediaEvents.Server.MediaEvent.Track
 end
 
 defmodule Fishjam.MediaEvents.Server.MediaEvent.Endpoint do
@@ -58,10 +57,10 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.Endpoint do
   field :endpoint_type, 2, type: :string, json_name: "endpointType"
   field :metadata_json, 3, type: :string, json_name: "metadataJson"
 
-  field :track_id_to_metadata_json, 4,
+  field :track_id_to_track, 4,
     repeated: true,
-    type: Fishjam.MediaEvents.Server.MediaEvent.Endpoint.TrackIdToMetadataJsonEntry,
-    json_name: "trackIdToMetadataJson",
+    type: Fishjam.MediaEvents.Server.MediaEvent.Endpoint.TrackIdToTrackEntry,
+    json_name: "trackIdToTrack",
     map: true
 end
 
@@ -94,13 +93,13 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.TrackUpdated do
   field :metadata_json, 3, type: :string, json_name: "metadataJson"
 end
 
-defmodule Fishjam.MediaEvents.Server.MediaEvent.TracksAdded.TrackIdToMetadataJsonEntry do
+defmodule Fishjam.MediaEvents.Server.MediaEvent.TracksAdded.TrackIdToTrackEntry do
   @moduledoc false
 
   use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
 
   field :key, 1, type: :string
-  field :value, 2, type: :string
+  field :value, 2, type: Fishjam.MediaEvents.Server.MediaEvent.Track
 end
 
 defmodule Fishjam.MediaEvents.Server.MediaEvent.TracksAdded do
@@ -110,10 +109,10 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.TracksAdded do
 
   field :endpoint_id, 1, type: :string, json_name: "endpointId"
 
-  field :track_id_to_metadata_json, 2,
+  field :track_id_to_track, 2,
     repeated: true,
-    type: Fishjam.MediaEvents.Server.MediaEvent.TracksAdded.TrackIdToMetadataJsonEntry,
-    json_name: "trackIdToMetadataJson",
+    type: Fishjam.MediaEvents.Server.MediaEvent.TracksAdded.TrackIdToTrackEntry,
+    json_name: "trackIdToTrack",
     map: true
 end
 
@@ -135,7 +134,7 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.EndpointAdded do
   field :metadata_json, 2, type: :string, json_name: "metadataJson"
 end
 
-defmodule Fishjam.MediaEvents.Server.MediaEvent.Connected.EndpointsIdToEndpointEntry do
+defmodule Fishjam.MediaEvents.Server.MediaEvent.Connected.EndpointIdToEndpointEntry do
   @moduledoc false
 
   use Protobuf, map: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
@@ -151,10 +150,10 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.Connected do
 
   field :endpoint_id, 1, type: :string, json_name: "endpointId"
 
-  field :endpoints_id_to_endpoint, 2,
+  field :endpoint_id_to_endpoint, 2,
     repeated: true,
-    type: Fishjam.MediaEvents.Server.MediaEvent.Connected.EndpointsIdToEndpointEntry,
-    json_name: "endpointsIdToEndpoint",
+    type: Fishjam.MediaEvents.Server.MediaEvent.Connected.EndpointIdToEndpointEntry,
+    json_name: "endpointIdToEndpoint",
     map: true
 
   field :ice_servers, 3,

--- a/fishjam_protos/lib/fishjam/media_events/server/server.pb.ex
+++ b/fishjam_protos/lib/fishjam/media_events/server/server.pb.ex
@@ -8,6 +8,39 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.VadNotification.Status do
   field :STATUS_SPEECH, 2
 end
 
+defmodule Fishjam.MediaEvents.Server.MediaEvent.Track.SimulcastConfig do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :enabled, 1, type: :bool
+
+  field :active_variants, 2,
+    repeated: true,
+    type: Fishjam.MediaEvents.Variant,
+    json_name: "activeVariants",
+    enum: true
+
+  field :disabled_variants, 3,
+    repeated: true,
+    type: Fishjam.MediaEvents.Variant,
+    json_name: "disabledVariants",
+    enum: true
+end
+
+defmodule Fishjam.MediaEvents.Server.MediaEvent.Track do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :track_id, 1, type: :string, json_name: "trackId"
+  field :metadata_json, 2, type: :string, json_name: "metadataJson"
+
+  field :simulcast_config, 3,
+    type: Fishjam.MediaEvents.Server.MediaEvent.Track.SimulcastConfig,
+    json_name: "simulcastConfig"
+end
+
 defmodule Fishjam.MediaEvents.Server.MediaEvent.Endpoint.TrackIdToMetadataJsonEntry do
   @moduledoc false
 
@@ -197,6 +230,36 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent.VadNotification do
   field :status, 2, type: Fishjam.MediaEvents.Server.MediaEvent.VadNotification.Status, enum: true
 end
 
+defmodule Fishjam.MediaEvents.Server.MediaEvent.TrackVariantSwitched do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :endpoint_id, 1, type: :string, json_name: "endpointId"
+  field :track_id, 2, type: :string, json_name: "trackId"
+  field :variant, 3, type: Fishjam.MediaEvents.Variant, enum: true
+end
+
+defmodule Fishjam.MediaEvents.Server.MediaEvent.TrackVariantDisabled do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :endpoint_id, 1, type: :string, json_name: "endpointId"
+  field :track_id, 2, type: :string, json_name: "trackId"
+  field :variant, 3, type: Fishjam.MediaEvents.Variant, enum: true
+end
+
+defmodule Fishjam.MediaEvents.Server.MediaEvent.TrackVariantEnabled do
+  @moduledoc false
+
+  use Protobuf, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :endpoint_id, 1, type: :string, json_name: "endpointId"
+  field :track_id, 2, type: :string, json_name: "trackId"
+  field :variant, 3, type: Fishjam.MediaEvents.Variant, enum: true
+end
+
 defmodule Fishjam.MediaEvents.Server.MediaEvent do
   @moduledoc false
 
@@ -252,5 +315,20 @@ defmodule Fishjam.MediaEvents.Server.MediaEvent do
   field :vad_notification, 12,
     type: Fishjam.MediaEvents.Server.MediaEvent.VadNotification,
     json_name: "vadNotification",
+    oneof: 0
+
+  field :track_variant_switched, 13,
+    type: Fishjam.MediaEvents.Server.MediaEvent.TrackVariantSwitched,
+    json_name: "trackVariantSwitched",
+    oneof: 0
+
+  field :track_variant_disabled, 14,
+    type: Fishjam.MediaEvents.Server.MediaEvent.TrackVariantDisabled,
+    json_name: "trackVariantDisabled",
+    oneof: 0
+
+  field :track_variant_enabled, 15,
+    type: Fishjam.MediaEvents.Server.MediaEvent.TrackVariantEnabled,
+    json_name: "trackVariantEnabled",
     oneof: 0
 end

--- a/fishjam_protos/lib/fishjam/media_events/shared.pb.ex
+++ b/fishjam_protos/lib/fishjam/media_events/shared.pb.ex
@@ -1,3 +1,14 @@
+defmodule Fishjam.MediaEvents.Variant do
+  @moduledoc false
+
+  use Protobuf, enum: true, syntax: :proto3, protoc_gen_elixir_version: "0.13.0"
+
+  field :VARIANT_UNSPECIFIED, 0
+  field :VARIANT_LOW, 1
+  field :VARIANT_MEDIUM, 2
+  field :VARIANT_HIGH, 3
+end
+
 defmodule Fishjam.MediaEvents.Candidate do
   @moduledoc false
 


### PR DESCRIPTION
Add minimal set of simulcast messages, allowing for sending simulcast tracks, and receiving them with manual variant selection.

I propose only providing bitrates for simulcast tracks. The bitrate values in Engine are used solely for calculating the appropriate variant sent to other peers. So any bitrate values sent for non-simulcast tracks are just ignored.

I also removed `Reason` from the `VariantSwitched` message. The reason is not used in Web Client and its only role (if any) would be to provide feedback to users, which is not important.