### PR TITLE
Add interruption events

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -8,6 +8,8 @@
     - [AgentRequest.AddTrack](#fishjam-AgentRequest-AddTrack)
     - [AgentRequest.AddTrack.CodecParameters](#fishjam-AgentRequest-AddTrack-CodecParameters)
     - [AgentRequest.AuthRequest](#fishjam-AgentRequest-AuthRequest)
+    - [AgentRequest.InterruptAllTracks](#fishjam-AgentRequest-InterruptAllTracks)
+    - [AgentRequest.InterruptTrack](#fishjam-AgentRequest-InterruptTrack)
     - [AgentRequest.RemoveTrack](#fishjam-AgentRequest-RemoveTrack)
     - [AgentRequest.TrackData](#fishjam-AgentRequest-TrackData)
     - [AgentResponse](#fishjam-AgentResponse)
@@ -133,6 +135,8 @@ Defines any type of message passed from agent peer to Fishjam
 | add_track | [AgentRequest.AddTrack](#fishjam-AgentRequest-AddTrack) |  |  |
 | remove_track | [AgentRequest.RemoveTrack](#fishjam-AgentRequest-RemoveTrack) |  |  |
 | track_data | [AgentRequest.TrackData](#fishjam-AgentRequest-TrackData) |  |  |
+| interrupt_track | [AgentRequest.InterruptTrack](#fishjam-AgentRequest-InterruptTrack) |  |  |
+| interrupt_all_tracks | [AgentRequest.InterruptAllTracks](#fishjam-AgentRequest-InterruptAllTracks) |  |  |
 
 
 
@@ -181,6 +185,31 @@ Request sent by agent, to authenticate to Fishjam server
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | token | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="fishjam-AgentRequest-InterruptAllTracks"></a>
+
+### AgentRequest.InterruptAllTracks
+Interrupts all of the agent&#39;s outgoing tracks, preventing already queued audio from being played
+
+
+
+
+
+
+<a name="fishjam-AgentRequest-InterruptTrack"></a>
+
+### AgentRequest.InterruptTrack
+Interrupts an agent&#39;s outgoing track, preventing already queued audio from being played
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| track_id | [string](#string) |  |  |
 
 
 

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -8,7 +8,6 @@
     - [AgentRequest.AddTrack](#fishjam-AgentRequest-AddTrack)
     - [AgentRequest.AddTrack.CodecParameters](#fishjam-AgentRequest-AddTrack-CodecParameters)
     - [AgentRequest.AuthRequest](#fishjam-AgentRequest-AuthRequest)
-    - [AgentRequest.InterruptAllTracks](#fishjam-AgentRequest-InterruptAllTracks)
     - [AgentRequest.InterruptTrack](#fishjam-AgentRequest-InterruptTrack)
     - [AgentRequest.RemoveTrack](#fishjam-AgentRequest-RemoveTrack)
     - [AgentRequest.TrackData](#fishjam-AgentRequest-TrackData)
@@ -136,7 +135,6 @@ Defines any type of message passed from agent peer to Fishjam
 | remove_track | [AgentRequest.RemoveTrack](#fishjam-AgentRequest-RemoveTrack) |  |  |
 | track_data | [AgentRequest.TrackData](#fishjam-AgentRequest-TrackData) |  |  |
 | interrupt_track | [AgentRequest.InterruptTrack](#fishjam-AgentRequest-InterruptTrack) |  |  |
-| interrupt_all_tracks | [AgentRequest.InterruptAllTracks](#fishjam-AgentRequest-InterruptAllTracks) |  |  |
 
 
 
@@ -185,16 +183,6 @@ Request sent by agent, to authenticate to Fishjam server
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | token | [string](#string) |  |  |
-
-
-
-
-
-
-<a name="fishjam-AgentRequest-InterruptAllTracks"></a>
-
-### AgentRequest.InterruptAllTracks
-Interrupts all of the agent&#39;s outgoing tracks, preventing already queued audio from being played
 
 
 

--- a/fishjam/agent_notifications.proto
+++ b/fishjam/agent_notifications.proto
@@ -39,11 +39,21 @@ message AgentRequest {
     bytes data = 2;
   }
 
+  // Interrupts an agent's outgoing track, preventing already queued audio from being played
+  message InterruptTrack {
+    string track_id = 1;
+  }
+
+  // Interrupts all of the agent's outgoing tracks, preventing already queued audio from being played
+  message InterruptAllTracks {}
+
   oneof content {
     AuthRequest auth_request = 1;
     AddTrack add_track = 2;
     RemoveTrack remove_track = 3;
     TrackData track_data = 4;
+    InterruptTrack interrupt_track = 5;
+    InterruptAllTracks interrupt_all_tracks = 6;
   }
 }
 

--- a/fishjam/agent_notifications.proto
+++ b/fishjam/agent_notifications.proto
@@ -44,16 +44,12 @@ message AgentRequest {
     string track_id = 1;
   }
 
-  // Interrupts all of the agent's outgoing tracks, preventing already queued audio from being played
-  message InterruptAllTracks {}
-
   oneof content {
     AuthRequest auth_request = 1;
     AddTrack add_track = 2;
     RemoveTrack remove_track = 3;
     TrackData track_data = 4;
     InterruptTrack interrupt_track = 5;
-    InterruptAllTracks interrupt_all_tracks = 6;
   }
 }
 

--- a/fishjam_protos/lib/fishjam/agent_notifications.pb.ex
+++ b/fishjam_protos/lib/fishjam/agent_notifications.pb.ex
@@ -53,12 +53,6 @@ defmodule Fishjam.AgentRequest.InterruptTrack do
   field :track_id, 1, type: :string, json_name: "trackId"
 end
 
-defmodule Fishjam.AgentRequest.InterruptAllTracks do
-  @moduledoc false
-
-  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto3
-end
-
 defmodule Fishjam.AgentRequest do
   @moduledoc false
 
@@ -83,11 +77,6 @@ defmodule Fishjam.AgentRequest do
   field :interrupt_track, 5,
     type: Fishjam.AgentRequest.InterruptTrack,
     json_name: "interruptTrack",
-    oneof: 0
-
-  field :interrupt_all_tracks, 6,
-    type: Fishjam.AgentRequest.InterruptAllTracks,
-    json_name: "interruptAllTracks",
     oneof: 0
 end
 

--- a/fishjam_protos/lib/fishjam/agent_notifications.pb.ex
+++ b/fishjam_protos/lib/fishjam/agent_notifications.pb.ex
@@ -45,6 +45,20 @@ defmodule Fishjam.AgentRequest.TrackData do
   field :data, 2, type: :bytes
 end
 
+defmodule Fishjam.AgentRequest.InterruptTrack do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto3
+
+  field :track_id, 1, type: :string, json_name: "trackId"
+end
+
+defmodule Fishjam.AgentRequest.InterruptAllTracks do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.15.0", syntax: :proto3
+end
+
 defmodule Fishjam.AgentRequest do
   @moduledoc false
 
@@ -65,6 +79,16 @@ defmodule Fishjam.AgentRequest do
     oneof: 0
 
   field :track_data, 4, type: Fishjam.AgentRequest.TrackData, json_name: "trackData", oneof: 0
+
+  field :interrupt_track, 5,
+    type: Fishjam.AgentRequest.InterruptTrack,
+    json_name: "interruptTrack",
+    oneof: 0
+
+  field :interrupt_all_tracks, 6,
+    type: Fishjam.AgentRequest.InterruptAllTracks,
+    json_name: "interruptAllTracks",
+    oneof: 0
 end
 
 defmodule Fishjam.AgentResponse.Authenticated do


### PR DESCRIPTION
Added interruption events for agents:

1. `InterruptTrack` - cancels a single track

These events aim to allow users to cancel previously sent audio buffers from being played.

Example:
1. A user starts talking while an agent is talking.
2. The agent's builtin VAD notices that the user started talking and emits `audio.interrupted` event, which stops generation of audio.
3. When handling this event, the agent sends an `InterruptTrack` event to fishjam on the corresponding track.
4. Fishjam drops already queued buffers, to prevent them from being played
