### PR TITLE
Allow notification batching

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1386,7 +1386,6 @@ Request sent by peer, to authenticate to FJ server
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | token | [string](#string) |  |  |
-| supports_notification_batch | [bool](#bool) |  | If true, the server may deliver NotificationBatch in addition to single-notification ServerMessages. Defaults to false for websocket and old peers. |
 
 
 
@@ -1516,8 +1515,7 @@ Constraints (documented, not schema-enforced):
     them in order.
   - The batch is wire-atomic but not semantically atomic: emitting two
     batches vs. one batch of the same elements is equivalent.
-  - Sent only to peers that opted in via
-  AuthRequest.supports_notification_batch.
+  - Sent only to peers that opted in
 
 
 | Field | Type | Label | Description |

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1513,9 +1513,7 @@ Constraints (documented, not schema-enforced):
     recursive batches and receivers may treat them as a protocol violation.
   - Notifications are delivered in array order; consumers must process
     them in order.
-  - The batch is wire-atomic but not semantically atomic: emitting two
-    batches vs. one batch of the same elements is equivalent.
-  - Sent only to peers that opted in
+  - Sent only for webhooks, for peers that opted in
 
 
 | Field | Type | Label | Description |

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -1513,7 +1513,7 @@ Constraints (documented, not schema-enforced):
     recursive batches and receivers may treat them as a protocol violation.
   - Notifications are delivered in array order; consumers must process
     them in order.
-  - Sent only for webhooks, for peers that opted in
+  - Sent only for webhooks, for peers that .
 
 
 | Field | Type | Label | Description |

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -97,6 +97,7 @@
     - [ServerMessage.HlsPlayable](#fishjam-ServerMessage-HlsPlayable)
     - [ServerMessage.HlsUploadCrashed](#fishjam-ServerMessage-HlsUploadCrashed)
     - [ServerMessage.HlsUploaded](#fishjam-ServerMessage-HlsUploaded)
+    - [ServerMessage.NotificationBatch](#fishjam-ServerMessage-NotificationBatch)
     - [ServerMessage.PeerAdded](#fishjam-ServerMessage-PeerAdded)
     - [ServerMessage.PeerConnected](#fishjam-ServerMessage-PeerConnected)
     - [ServerMessage.PeerCrashed](#fishjam-ServerMessage-PeerCrashed)
@@ -1363,6 +1364,7 @@ Defines any type of message passed between FJ and server peer
 | viewer_disconnected | [ServerMessage.ViewerDisconnected](#fishjam-ServerMessage-ViewerDisconnected) |  |  |
 | streamer_connected | [ServerMessage.StreamerConnected](#fishjam-ServerMessage-StreamerConnected) |  |  |
 | streamer_disconnected | [ServerMessage.StreamerDisconnected](#fishjam-ServerMessage-StreamerDisconnected) |  |  |
+| notification_batch | [ServerMessage.NotificationBatch](#fishjam-ServerMessage-NotificationBatch) |  | Batch |
 | stream_connected | [ServerMessage.StreamConnected](#fishjam-ServerMessage-StreamConnected) |  | **Deprecated.**  |
 | stream_disconnected | [ServerMessage.StreamDisconnected](#fishjam-ServerMessage-StreamDisconnected) |  | **Deprecated.**  |
 | hls_playable | [ServerMessage.HlsPlayable](#fishjam-ServerMessage-HlsPlayable) |  | **Deprecated.**  |
@@ -1384,6 +1386,7 @@ Request sent by peer, to authenticate to FJ server
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | token | [string](#string) |  |  |
+| supports_notification_batch | [bool](#bool) |  | If true, the server may deliver NotificationBatch in addition to single-notification ServerMessages. Defaults to false for websocket and old peers. |
 
 
 
@@ -1492,6 +1495,34 @@ Notification sent when the HLS recording is successfully uploaded to AWS S3
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | room_id | [string](#string) |  |  |
+
+
+
+
+
+
+<a name="fishjam-ServerMessage-NotificationBatch"></a>
+
+### ServerMessage.NotificationBatch
+Carries multiple notifications in a single wire frame.
+
+Constraints (documented, not schema-enforced):
+  - Each element&#39;s `content` MUST be a notification variant — never
+    Authenticated, AuthRequest, SubscribeRequest, or SubscribeResponse.
+  - NotificationBatch MUST NOT be nested inside another NotificationBatch.
+    The schema technically permits this, but senders must not emit
+    recursive batches and receivers may treat them as a protocol violation.
+  - Notifications are delivered in array order; consumers must process
+    them in order.
+  - The batch is wire-atomic but not semantically atomic: emitting two
+    batches vs. one batch of the same elements is equivalent.
+  - Sent only to peers that opted in via
+  AuthRequest.supports_notification_batch.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| notifications | [ServerMessage](#fishjam-ServerMessage) | repeated |  |
 
 
 

--- a/fishjam/server_notifications.proto
+++ b/fishjam/server_notifications.proto
@@ -243,7 +243,7 @@ message ServerMessage {
   //     recursive batches and receivers may treat them as a protocol violation.
   //   - Notifications are delivered in array order; consumers must process
   //     them in order.
-  //   - Sent only for webhooks, for peers that opted in
+  //   - Sent only for webhooks, for peers that .
   message NotificationBatch {
     repeated ServerMessage notifications = 1;
   }

--- a/fishjam/server_notifications.proto
+++ b/fishjam/server_notifications.proto
@@ -64,13 +64,7 @@ message ServerMessage {
   message Authenticated {}
 
   // Request sent by peer, to authenticate to FJ server
-  message AuthRequest {
-    string token = 1;
-    // If true, the server may deliver NotificationBatch in addition to
-    // single-notification ServerMessages. Defaults to false for websocket and
-    // old peers.
-    bool supports_notification_batch = 2;
-  }
+  message AuthRequest { string token = 1; }
 
   // Defines message groups for which peer can subscribe
   enum EventType {
@@ -249,8 +243,7 @@ message ServerMessage {
   //     them in order.
   //   - The batch is wire-atomic but not semantically atomic: emitting two
   //     batches vs. one batch of the same elements is equivalent.
-  //   - Sent only to peers that opted in via
-  //   AuthRequest.supports_notification_batch.
+  //   - Sent only to peers that opted in
   message NotificationBatch { repeated ServerMessage notifications = 1; }
 
   reserved 12;

--- a/fishjam/server_notifications.proto
+++ b/fishjam/server_notifications.proto
@@ -243,9 +243,7 @@ message ServerMessage {
   //     recursive batches and receivers may treat them as a protocol violation.
   //   - Notifications are delivered in array order; consumers must process
   //     them in order.
-  //   - The batch is wire-atomic but not semantically atomic: emitting two
-  //     batches vs. one batch of the same elements is equivalent.
-  //   - Sent only to peers that opted in
+  //   - Sent only for webhooks, for peers that opted in
   message NotificationBatch {
     repeated ServerMessage notifications = 1;
   }

--- a/fishjam/server_notifications.proto
+++ b/fishjam/server_notifications.proto
@@ -66,6 +66,10 @@ message ServerMessage {
   // Request sent by peer, to authenticate to FJ server
   message AuthRequest {
     string token = 1;
+    // If true, the server may deliver NotificationBatch in addition to
+    // single-notification ServerMessages. Defaults to false for websocket and
+    // old peers.
+    bool supports_notification_batch = 2;
   }
 
   // Defines message groups for which peer can subscribe
@@ -233,6 +237,22 @@ message ServerMessage {
     string streamer_id = 2;
   }
 
+  // Carries multiple notifications in a single wire frame.
+  //
+  // Constraints (documented, not schema-enforced):
+  //   - Each element's `content` MUST be a notification variant — never
+  //     Authenticated, AuthRequest, SubscribeRequest, or SubscribeResponse.
+  //   - NotificationBatch MUST NOT be nested inside another NotificationBatch.
+  //     The schema technically permits this, but senders must not emit
+  //     recursive batches and receivers may treat them as a protocol violation.
+  //   - Notifications are delivered in array order; consumers must process
+  //     them in order.
+  //   - The batch is wire-atomic but not semantically atomic: emitting two
+  //     batches vs. one batch of the same elements is equivalent.
+  //   - Sent only to peers that opted in via
+  //   AuthRequest.supports_notification_batch.
+  message NotificationBatch { repeated ServerMessage notifications = 1; }
+
   reserved 12;
 
   oneof content {
@@ -272,6 +292,9 @@ message ServerMessage {
     ViewerDisconnected viewer_disconnected = 25;
     StreamerConnected streamer_connected = 26;
     StreamerDisconnected streamer_disconnected = 27;
+
+    // Batch
+    NotificationBatch notification_batch = 33;
 
     // Deprecated
 

--- a/fishjam/server_notifications.proto
+++ b/fishjam/server_notifications.proto
@@ -64,7 +64,9 @@ message ServerMessage {
   message Authenticated {}
 
   // Request sent by peer, to authenticate to FJ server
-  message AuthRequest { string token = 1; }
+  message AuthRequest {
+    string token = 1;
+  }
 
   // Defines message groups for which peer can subscribe
   enum EventType {
@@ -244,7 +246,9 @@ message ServerMessage {
   //   - The batch is wire-atomic but not semantically atomic: emitting two
   //     batches vs. one batch of the same elements is equivalent.
   //   - Sent only to peers that opted in
-  message NotificationBatch { repeated ServerMessage notifications = 1; }
+  message NotificationBatch {
+    repeated ServerMessage notifications = 1;
+  }
 
   reserved 12;
 

--- a/fishjam_protos/lib/fishjam/server_notifications.pb.ex
+++ b/fishjam_protos/lib/fishjam/server_notifications.pb.ex
@@ -147,7 +147,6 @@ defmodule Fishjam.ServerMessage.AuthRequest do
     syntax: :proto3
 
   field :token, 1, type: :string
-  field :supports_notification_batch, 2, type: :bool, json_name: "supportsNotificationBatch"
 end
 
 defmodule Fishjam.ServerMessage.SubscribeRequest do

--- a/fishjam_protos/lib/fishjam/server_notifications.pb.ex
+++ b/fishjam_protos/lib/fishjam/server_notifications.pb.ex
@@ -147,6 +147,7 @@ defmodule Fishjam.ServerMessage.AuthRequest do
     syntax: :proto3
 
   field :token, 1, type: :string
+  field :supports_notification_batch, 2, type: :bool, json_name: "supportsNotificationBatch"
 end
 
 defmodule Fishjam.ServerMessage.SubscribeRequest do
@@ -443,6 +444,17 @@ defmodule Fishjam.ServerMessage.StreamerDisconnected do
   field :streamer_id, 2, type: :string, json_name: "streamerId"
 end
 
+defmodule Fishjam.ServerMessage.NotificationBatch do
+  @moduledoc false
+
+  use Protobuf,
+    full_name: "fishjam.ServerMessage.NotificationBatch",
+    protoc_gen_elixir_version: "0.16.0",
+    syntax: :proto3
+
+  field :notifications, 1, repeated: true, type: Fishjam.ServerMessage
+end
+
 defmodule Fishjam.ServerMessage do
   @moduledoc false
 
@@ -570,6 +582,11 @@ defmodule Fishjam.ServerMessage do
   field :streamer_disconnected, 27,
     type: Fishjam.ServerMessage.StreamerDisconnected,
     json_name: "streamerDisconnected",
+    oneof: 0
+
+  field :notification_batch, 33,
+    type: Fishjam.ServerMessage.NotificationBatch,
+    json_name: "notificationBatch",
     oneof: 0
 
   field :stream_connected, 22,

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,8 @@
+set -e
+
+find fishjam -name "*.proto" | sort | xargs docker run --rm -v $(pwd)/doc:/out -v $(pwd):/protos pseudomuto/protoc-gen-doc --doc_opt=markdown,docs.md
+
+buf lint
+buf format -w
+
+(cd ./fishjam_protos;  ./compile_proto.sh)

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,8 +1,10 @@
+#!/bin/bash
+
 set -e
 
-find fishjam -name "*.proto" | sort | xargs docker run --rm -v $(pwd)/doc:/out -v $(pwd):/protos pseudomuto/protoc-gen-doc --doc_opt=markdown,docs.md
+find fishjam -name "*.proto" | sort | xargs docker run --rm -v $PWD/doc:/out -v $PWD:/protos pseudomuto/protoc-gen-doc --doc_opt=markdown,docs.md
 
-buf lint
 buf format -w
+buf lint
 
 (cd ./fishjam_protos;  ./compile_proto.sh)


### PR DESCRIPTION
## Description

- Goal: send multiple notifications per wire frame without breaking peers built
  against the old schema.

Considered alternatives

- Dedicated Notification message inside ServerMessage as oneof option: structurally rules out
  recursion, but every new notification has to be added in two places with
  matching tags — too costly to maintain.
- Top-level ServerMessageBatch sibling of ServerMessage: structural
  non-recursion for free, but forces the receiving side to know which message type is being received at the moment

Trade-off accepted: schema permits a batch-of-batches; doc comment forbids it.
Reuse of ServerMessage keeps future notifications a one-line addition.

## Motivation and Context

Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required
