### PR TITLE
docs: add AGENTS.md with Cursor Cloud specific setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# protos
+
+Fishjam protobuf definitions, managed with `buf`.
+
+## Cursor Cloud specific instructions
+
+`buf` is pre-installed (via `mise`). Non-obvious notes:
+
+- Validated: `buf lint`, `buf build`, `buf format` (all pass on `fishjam/`).
+- `prepare.sh` regenerates docs and the Elixir bindings; it uses Docker (`pseudomuto/protoc-gen-doc`) and `fishjam_protos/compile_proto.sh` needs `protoc` with the Elixir plugin plus the Elixir toolchain from `fishjam_protos/.tool-versions`. Those codegen steps are not required just to lint/build the protos.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` documenting Cursor Cloud dev-environment setup. No production code changes. Validated: `buf lint`, `buf build`, `buf format`. Codegen (`prepare.sh`, `fishjam_protos/compile_proto.sh`) additionally needs Docker + protoc's Elixir plugin.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d2d55e2-cb0f-49b0-8d5f-15c80c2982c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d2d55e2-cb0f-49b0-8d5f-15c80c2982c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

